### PR TITLE
Fix changelog.css

### DIFF
--- a/changelog/changelog.css
+++ b/changelog/changelog.css
@@ -1,7 +1,7 @@
-a.changeset-link {
+a.changelog-reference {
 	visibility: hidden;
 }
 
-li:hover a.changeset-link {
+li:hover a.changelog-reference {
    visibility: visible;
 }


### PR DESCRIPTION
CSS class for change link was renamed here:
https://github.com/dolfinus/changelog/commit/3ca7d3c3dea7dcff0e952f341abfe9ee5be844ae#diff-d8880371af7fc74fc57861356ee97d47L152

But still left intact in the CSS file. Because of that hover event on this link does not work, and all the changelog now full of ¶ signs:
![image](https://user-images.githubusercontent.com/4661021/94052196-42e51600-fde1-11ea-9317-26491934d668.png)

This PR should fix the issue.
