### PR TITLE
Fix repo link in setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,21 @@
 Changelog
 ==========
 
-A `Sphinx <http://sphinx.pocoo.org/>`_ extension to generate changelog files.
+|PyPI| |Python| |Downloads|
+
+.. |PyPI| image:: https://img.shields.io/pypi/v/changelog
+    :target: https://pypi.org/project/changelog
+    :alt: PyPI
+
+.. |Python| image:: https://img.shields.io/pypi/pyversions/changelog
+    :target: https://pypi.org/project/changelog
+    :alt: PyPI - Python Version
+
+.. |Downloads| image:: https://img.shields.io/pypi/dm/changelog
+    :target: https://pypi.org/project/changelog
+    :alt: PyPI - Downloads
+
+A `Sphinx <https://www.sphinx-doc.org>`_ extension to generate changelog files.
 
 This is an experimental, possibly-not-useful extension that's used by the
 `SQLAlchemy <http://www.sqlalchemy.org>`_ project and related projects.

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     keywords="Sphinx",
     author="Mike Bayer",
     author_email="mike@zzzcomputing.com",
-    url="http://bitbucket.org/zzzeek/changelog",
+    url="https://github.com/sqlalchemyorg/changelog",
     license="MIT",
     packages=["changelog"],
     include_package_data=True,


### PR DESCRIPTION
Currently PyPi [project page](https://pypi.org/project/changelog) shows old repo link: http://bitbucket.org/zzzeek/changelog

I've fixed the url and also added few badges to README to make navigation a bit easier.
