### PR TITLE
Render backported versions as links

### DIFF
--- a/changelog/generate_rst.py
+++ b/changelog/generate_rst.py
@@ -162,13 +162,24 @@ def _render_rec(changelog_directive, rec, section, cat, append_sec):
             rec["sorted_versions"].index(changelog_directive.version) + 1 :
         ]
         if backported_changes:
-            backported = nodes.paragraph("")
-            backported.append(nodes.Text("This change is also ", ""))
-            backported.append(nodes.strong("", "backported"))
-            backported.append(
-                nodes.Text(" to: %s" % ", ".join(backported_changes), "")
-            )
-            para.append(backported)
+            backported_para = nodes.paragraph("")
+            backported_para.append(nodes.Text("This change is also ", ""))
+            backported_para.append(nodes.strong("", "backported"))
+            backported_para.append(nodes.Text(" to: ", ""))
+
+            for i, backported in enumerate(backported_changes):
+                backported_para.append(
+                    nodes.reference(
+                    "",
+                    "",
+                    nodes.Text(backported, backported),
+                    refid="change-%s" % backported,
+                ))
+
+                if i != len(backported_changes)-1:
+                    backported_para.append(nodes.Text(", ", ""))
+
+            para.append(backported_para)
 
     insert_ticket = nodes.paragraph("")
     para.append(insert_ticket)


### PR DESCRIPTION
If you add `versions` to some change, the information that this change was backported to some another version is shown.

But currently this list of versions is just a text:
![Screenshot_20200923_231103](https://user-images.githubusercontent.com/4661021/94064546-8431f180-fdf2-11ea-98bd-29ce01639758.png)

This pull request make each version in this list a hyperlink to related changelog part:
![Screenshot_20200923_225830](https://user-images.githubusercontent.com/4661021/94063787-4da7a700-fdf1-11ea-8f02-5fa834f33d04.png)
