### PR TITLE
Allow to hide sections from tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,9 @@ A sample configuration in ``conf.py`` looks like this::
     # tags to sort on inside of sections - also optional
     changelog_inner_tag_sort = ["feature", "bug"]
 
+    # whether sections should be hidden from tags list
+    changelog_hide_sections_from_tags = False
+
     # how to render changelog links - these are plain
     # python string templates, ticket/pullreq/changeset number goes
     # in "%s"

--- a/changelog/docutils.py
+++ b/changelog/docutils.py
@@ -74,6 +74,7 @@ class ChangeLogDirective(EnvDirective, Directive):
         # 1. pull in global configuration from conf.py
         self.sections = self.env.changelog_sections
         self.inner_tag_sort = self.env.changelog_inner_tag_sort + [""]
+        self.hide_sections_from_tags = bool(self.env.changelog_hide_sections_from_tags)
 
         # 2. examine top level directives inside the .. changelog::
         # directive.  version, release date

--- a/changelog/environment.py
+++ b/changelog/environment.py
@@ -39,6 +39,10 @@ class Environment(object):
         raise NotImplementedError()
 
     @property
+    def changelog_hide_sections_from_tags(self):
+        raise NotImplementedError()
+
+    @property
     def changelog_render_ticket(self):
         raise NotImplementedError()
 
@@ -78,7 +82,11 @@ class DefaultEnvironment(Environment):
 
     @property
     def changelog_inner_tag_sort(self):
-        return self.config.get("inner_tag_sort", [])
+        return self.config.get("changelog_inner_tag_sort", [])
+
+    @property
+    def changelog_hide_sections_from_tags(self):
+        return self.config.get("changelog_hide_sections_from_tags", [])
 
     @property
     def changelog_render_ticket(self):

--- a/changelog/generate_rst.py
+++ b/changelog/generate_rst.py
@@ -146,7 +146,29 @@ def _render_rec(changelog_directive, rec, section, cat, append_sec):
         rec["version_to_hash"][changelog_directive.version],
     )
     targetnode = nodes.target("", "", ids=[targetid])
+
+    sections = section.split(" ")
+    section_tags = [tag for tag in sections if tag in rec["tags"]]
+    category_tags = [cat] if cat in rec["tags"] else []
+    other_tags = list(sorted(rec["tags"].difference(section_tags+category_tags)))
+
+    all_items = []
+
+    if not changelog_directive.hide_sections_from_tags:
+        all_items.extend(section_tags)
+    all_items.extend(category_tags)
+    all_items.extend(other_tags)
+
+    if all_items:
+        tag_node = nodes.strong(
+            "",
+            " ".join("[%s]" % t for t in all_items),
+        )
+        targetnode.insert(0, nodes.Text(" ", " "))
+        targetnode.insert(0, tag_node)
+
     para.insert(0, targetnode)
+
     permalink = nodes.reference(
         "",
         "",
@@ -216,18 +238,6 @@ def _render_rec(changelog_directive, rec, section, cat, append_sec):
             else:
                 node = nodes.Text(prefix % refname, prefix % refname)
             insert_ticket.append(node)
-
-    if rec["tags"]:
-        tag_node = nodes.strong(
-            "",
-            " ".join(
-                "[%s]" % t
-                for t in [t1 for t1 in [section, cat] if t1 in rec["tags"]]
-                + list(sorted(rec["tags"].difference([section, cat])))
-            ),
-        )
-        para.children[0].insert(0, nodes.Text(" ", " "))
-        para.children[0].insert(0, tag_node)
 
     append_sec.append(
         nodes.list_item("", nodes.target("", "", ids=[rec["id"]]), para)

--- a/changelog/sphinxext.py
+++ b/changelog/sphinxext.py
@@ -45,6 +45,10 @@ class SphinxEnvironment(Environment):
         return self.sphinx_env.config.changelog_inner_tag_sort
 
     @property
+    def changelog_hide_sections_from_tags(self):
+        return self.sphinx_env.config.changelog_hide_sections_from_tags
+
+    @property
     def changelog_render_ticket(self):
         return self.sphinx_env.config.changelog_render_ticket
 
@@ -99,6 +103,7 @@ def setup(app):
     app.add_directive("changelog_imports", ChangeLogImportDirective)
     app.add_config_value("changelog_sections", [], "env")
     app.add_config_value("changelog_inner_tag_sort", [], "env")
+    app.add_config_value("changelog_hide_sections_from_tags", False, "env")
     app.add_config_value("changelog_render_ticket", None, "env")
     app.add_config_value("changelog_render_pullreq", None, "env")
     app.add_config_value("changelog_render_changeset", None, "env")


### PR DESCRIPTION
Currently if user defined `changelog_sections` with some sections list, they will still show in the list of tags:
![Screenshot_20200923_231130](https://user-images.githubusercontent.com/4661021/94064710-c1967f00-fdf2-11ea-9030-701f71ea5433.png)

It can look okay on some small lists, but when you have lots of changes, it suddenly became too dirty:
![Screenshot_20200923_231635](https://user-images.githubusercontent.com/4661021/94064893-fefb0c80-fdf2-11ea-9aaa-009d75a86721.png)

This PR adds new option `changelog_hide_sections_from_tags`. If it is `False` (default value), the same behavior remains. But if user set it to `True`, section names dissapear, just like in `misc` section:
![Screenshot_20200923_231102](https://user-images.githubusercontent.com/4661021/94065160-6a44de80-fdf3-11ea-92e5-237b172a73d0.png)

And now it looks a bit cleaner, IMHO:
![Screenshot_20200923_232520](https://user-images.githubusercontent.com/4661021/94065867-5cdc2400-fdf4-11ea-8ae4-a78c9df4d061.png)
