### PR TITLE
Move reference link to tags list

### DIFF
--- a/changelog/docutils.py
+++ b/changelog/docutils.py
@@ -205,7 +205,7 @@ class ChangeDirective(EnvDirective, Directive):
 
             return []
 
-        body_paragraph = nodes.paragraph("", "")
+        body_paragraph = nodes.paragraph("", "", classes=["caption"])
         self.state.nested_parse(content["text"], 0, body_paragraph)
 
         raw_text = _text_rawsource_from_node(body_paragraph)

--- a/changelog/generate_rst.py
+++ b/changelog/generate_rst.py
@@ -146,7 +146,7 @@ def _render_rec(changelog_directive, rec, section, cat, append_sec):
         rec["version_to_hash"][changelog_directive.version],
     )
     targetnode = nodes.target("", "", ids=[targetid])
-    para.insert(0, targetnode)
+
     permalink = nodes.reference(
         "",
         "",
@@ -154,7 +154,8 @@ def _render_rec(changelog_directive, rec, section, cat, append_sec):
         refid=targetid,
         classes=["changelog-reference", "headerlink"],
     )
-    para.append(permalink)
+    targetnode.append(permalink)
+    para.insert(0, targetnode)
 
     if len(rec["versions"]) > 1:
 
@@ -217,13 +218,14 @@ def _render_rec(changelog_directive, rec, section, cat, append_sec):
                 node = nodes.Text(prefix % refname, prefix % refname)
             insert_ticket.append(node)
 
-    if rec["tags"]:
+    tags = rec["tags"] or {'no_tags'}
+    if tags:
         tag_node = nodes.strong(
             "",
             " ".join(
                 "[%s]" % t
-                for t in [t1 for t1 in [section, cat] if t1 in rec["tags"]]
-                + list(sorted(rec["tags"].difference([section, cat])))
+                for t in [t1 for t1 in [section, cat] if t1 in tags]
+                + list(sorted(tags.difference([section, cat])))
             ),
         )
         para.children[0].insert(0, nodes.Text(" ", " "))


### PR DESCRIPTION
Currently ¶ element is shown just after change description.
But version and section headers have a link icon not below, but at the same line the caption is shown:
![Peek 2020-09-23 23-41](https://user-images.githubusercontent.com/4661021/94067567-c0675100-fdf6-11ea-88a4-744c6a648da5.gif)


IMHO, there is too much empty space between change description and it's references. It is even look like references list is connected with next change, not the current one, especially using the same there like on SQLAlchemy changelog page:
![image](https://user-images.githubusercontent.com/4661021/94068619-1b4d7800-fdf8-11ea-9a7a-458145726661.png)

It's be better to add link not below the description block, but at the line of tags list, just after all of them:
![Peek 2020-09-23 23-40](https://user-images.githubusercontent.com/4661021/94067692-ebea3b80-fdf6-11ea-9e32-5e630352e478.gif)

Also because of adding `caption` class to the paragraph containing headlink, ReadTheDocs theme now can correctly rewrite icon of this link to `chain` icon, just the same as used for headers. It'll not affect other themes which ignore this class, like SQLAlchemy changes page theme.