### PR TITLE
Add changelog_section_classes option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,9 @@ A sample configuration in ``conf.py`` looks like this::
     # section names - optional
     changelog_sections = ["general", "rendering", "tests"]
 
+    # section css classes - optional
+    changelog_caption_class = "caption"
+
     # tags to sort on inside of sections - also optional
     changelog_inner_tag_sort = ["feature", "bug"]
 

--- a/changelog/docutils.py
+++ b/changelog/docutils.py
@@ -73,6 +73,7 @@ class ChangeLogDirective(EnvDirective, Directive):
     def _parse(self):
         # 1. pull in global configuration from conf.py
         self.sections = self.env.changelog_sections
+        self.caption_classes = self.env.changelog_caption_class.split(" ")
         self.inner_tag_sort = self.env.changelog_inner_tag_sort + [""]
         self.hide_sections_from_tags = bool(
             self.env.changelog_hide_sections_from_tags
@@ -211,7 +212,7 @@ class ChangeDirective(EnvDirective, Directive):
 
             return []
 
-        body_paragraph = nodes.paragraph("", "", classes=["caption"])
+        body_paragraph = nodes.paragraph("", "", classes=changelog_directive.caption_classes)
         self.state.nested_parse(content["text"], 0, body_paragraph)
 
         raw_text = _text_rawsource_from_node(body_paragraph)

--- a/changelog/environment.py
+++ b/changelog/environment.py
@@ -35,6 +35,10 @@ class Environment(object):
         raise NotImplementedError()
 
     @property
+    def changelog_caption_class(self):
+        raise NotImplementedError()
+
+    @property
     def changelog_inner_tag_sort(self):
         raise NotImplementedError()
 
@@ -79,6 +83,10 @@ class DefaultEnvironment(Environment):
     @property
     def changelog_sections(self):
         return self.config.get("changelog_sections", [])
+
+    @property
+    def changelog_caption_class(self):
+        return self.config.get("changelog_caption_class", "caption")
 
     @property
     def changelog_inner_tag_sort(self):

--- a/changelog/sphinxext.py
+++ b/changelog/sphinxext.py
@@ -41,6 +41,10 @@ class SphinxEnvironment(Environment):
         return self.sphinx_env.config.changelog_sections
 
     @property
+    def changelog_caption_class(self):
+        return self.sphinx_env.config.changelog_caption_class
+
+    @property
     def changelog_inner_tag_sort(self):
         return self.sphinx_env.config.changelog_inner_tag_sort
 
@@ -106,6 +110,7 @@ def setup(app):
     app.add_directive("change", ChangeDirective)
     app.add_directive("changelog_imports", ChangeLogImportDirective)
     app.add_config_value("changelog_sections", [], "env")
+    app.add_config_value("changelog_caption_class", "caption", "env")
     app.add_config_value("changelog_inner_tag_sort", [], "env")
     app.add_config_value("changelog_hide_sections_from_tags", False, "env")
     app.add_config_value("changelog_hide_tags_in_entry", False, "env")


### PR DESCRIPTION
Hello.

In #5 I've added default class `"caption"` for changelog paragraph:
https://github.com/sqlalchemyorg/changelog/pull/5/files#diff-a540b65c33c3dd7cc870a1f11b73efe6ecac1c0057e82843b009ec1858deb913R208

This was caused by [attempt](https://github.com/sqlalchemyorg/changelog/pull/5#issue-707669373) to fix link icon in ReadTheDocs theme which I used at the moment.

But now I'm using new [Furo](https://github.com/pradyunsg/furo) theme which CSS style:
```css
.code-block-caption, article p.caption, table>caption {
    font-size: var(--font-size--small);
    text-align: center;
}
```

causes the unusual changelog rendering:
https://setuptools-git-versioning.readthedocs.io/en/latest/changelog.html#change-65b87b65314ef3a77152c9765443d623
![2022-01-06_18-30](https://user-images.githubusercontent.com/4661021/148409482-60f9fa8f-1910-419c-b53b-95e5174b89fe.png)

But it is absolutely fine if I remove `"caption"` class:
![2022-01-06_18-30_1](https://user-images.githubusercontent.com/4661021/148409521-a515a405-ece4-45b9-b7e2-01c2cd806bbf.png)

So I've added new option for the package which allows users to set up custom classes for paragraph according to documentation theme they use. Default value remains unchanged just to save existing behavior.